### PR TITLE
Implement lane-based player movement

### DIFF
--- a/src/GameScene.ts
+++ b/src/GameScene.ts
@@ -4,6 +4,7 @@ export default class GameScene extends Phaser.Scene {
   private player!: Phaser.GameObjects.Rectangle
   private score = 0
   private scoreText!: Phaser.GameObjects.Text
+  private laneIndex = 0 // -2 (left) to 2 (right)
 
   constructor() {
     super('GameScene')
@@ -19,6 +20,12 @@ export default class GameScene extends Phaser.Scene {
     // Create player as a simple rectangle placeholder
     this.player = this.add.rectangle(width / 2, height * 0.8, 40, 60, 0x00ff00)
     this.physics.add.existing(this.player)
+
+    // Listen for taps to change direction
+    this.input.on('pointerdown', this.handlePointerDown, this)
+
+    // Ensure player is positioned in the center lane initially
+    this.updatePlayerPosition()
 
     // Display score in the top-right corner
     this.scoreText = this.add.text(width - 16, 16, 'Score: 0', {
@@ -38,6 +45,24 @@ export default class GameScene extends Phaser.Scene {
   private addScore(): void {
     this.score += 10
     this.scoreText.setText(`Score: ${this.score}`)
+  }
+
+  private handlePointerDown(pointer: Phaser.Input.Pointer): void {
+    const { width } = this.scale
+    if (pointer.downX < width / 2) {
+      this.laneIndex = Phaser.Math.Clamp(this.laneIndex - 1, -2, 2)
+    } else {
+      this.laneIndex = Phaser.Math.Clamp(this.laneIndex + 1, -2, 2)
+    }
+    this.updatePlayerPosition()
+  }
+
+  private updatePlayerPosition(): void {
+    const { width } = this.scale
+    const segmentWidth = width / 5
+    const index = this.laneIndex + 2
+    const x = segmentWidth * (index + 0.5)
+    this.player.setX(x)
   }
 
   update(): void {


### PR DESCRIPTION
## Summary
- allow tapping on screen halves to shift the player
- snap player x-position across five fixed lanes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871cf714b10832fa1bc7738aabe405c