### PR TITLE
Add Phaser SettingsScene with storage utils

### DIFF
--- a/src/SettingsScene.ts
+++ b/src/SettingsScene.ts
@@ -1,0 +1,62 @@
+import Phaser from 'phaser'
+import {
+  getBgmEnabled,
+  setBgmEnabled,
+  getSeEnabled,
+  setSeEnabled
+} from './utils/storage'
+
+export default class SettingsScene extends Phaser.Scene {
+  private bgmButton!: Phaser.GameObjects.Text
+  private seButton!: Phaser.GameObjects.Text
+
+  constructor() {
+    super('SettingsScene')
+  }
+
+  create(): void {
+    const { width, height } = this.scale
+
+    // simple background
+    this.add.rectangle(width / 2, height / 2, width, height, 0x202040)
+
+    this.bgmButton = this.add
+      .text(width / 2, height * 0.4, '', {
+        fontSize: '32px',
+        backgroundColor: '#1a1a1a',
+        color: '#ffffff',
+        padding: { x: 10, y: 5 }
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+
+    this.seButton = this.add
+      .text(width / 2, height * 0.55, '', {
+        fontSize: '32px',
+        backgroundColor: '#1a1a1a',
+        color: '#ffffff',
+        padding: { x: 10, y: 5 }
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+
+    this.updateLabels()
+
+    this.bgmButton.on('pointerdown', () => {
+      const enabled = !getBgmEnabled()
+      setBgmEnabled(enabled)
+      this.updateLabels()
+    })
+
+    this.seButton.on('pointerdown', () => {
+      const enabled = !getSeEnabled()
+      setSeEnabled(enabled)
+      this.updateLabels()
+    })
+  }
+
+  private updateLabels(): void {
+    this.bgmButton.setText(`BGM: ${getBgmEnabled() ? 'ON' : 'OFF'}`)
+    this.seButton.setText(`SE: ${getSeEnabled() ? 'ON' : 'OFF'}`)
+  }
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,17 @@
+export function getBgmEnabled(): boolean {
+  const stored = localStorage.getItem('bgmEnabled');
+  return stored !== null ? stored === 'true' : true;
+}
+
+export function setBgmEnabled(enabled: boolean): void {
+  localStorage.setItem('bgmEnabled', String(enabled));
+}
+
+export function getSeEnabled(): boolean {
+  const stored = localStorage.getItem('seEnabled');
+  return stored !== null ? stored === 'true' : true;
+}
+
+export function setSeEnabled(enabled: boolean): void {
+  localStorage.setItem('seEnabled', String(enabled));
+}


### PR DESCRIPTION
## Summary
- implement `utils/storage.ts` with get/set helpers for BGM and SE
- create `SettingsScene.ts` with toggle buttons that update labels and save to localStorage

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871d8144990832f8bd4064079c82e4a